### PR TITLE
Move key bindings to minor mode definition.

### DIFF
--- a/wakib-keys.el
+++ b/wakib-keys.el
@@ -506,18 +506,24 @@ Then add C-d and C-e to KEYMAP"
 	       (setq temporary-goal-column 0)))
       (move-end-of-line arg))))
 
+(defvar wakib--keymaps-initialized nil)
+
 (defun wakib--setup ()
   "Runs after minor mode change to setup minor mode"
+  (unless wakib--keymaps-initialized
+    (wakib-define-keys wakib-keys-overriding-map wakib-keylist)
+    (unless (display-graphic-p)
+      (define-key wakib-keys-overriding-map (kbd "M-O") 'wakib--tty-M-O))
+    (setq wakib--keymaps-initialized t))
+
   (if wakib-keys
       (progn
         (advice-add 'substitute-command-keys :around #'wakib-substitute-command-keys)
-	(advice-add 'describe-buffer-bindings :around #'wakib--describe-bindings-advice)
-        (wakib-define-keys wakib-keys-overriding-map wakib-keylist)
-        (unless (display-graphic-p)
-          (define-key wakib-keys-overriding-map (kbd "M-O") 'wakib--tty-M-O))
+        (advice-add 'describe-buffer-bindings :around #'wakib--describe-bindings-advice)
         (add-to-ordered-list 'emulation-mode-map-alists
                              `((wakib-keys . ,wakib-keys-overriding-map)) 400))
-    (setq emulation-mode-map-alists (delq 'wakib-keys-overriding-map emulation-mode-map-alists))
+    (setq emulation-mode-map-alists (delq `((wakib-keys . ,wakib-keys-overriding-map))
+                                          emulation-mode-map-alists))
     (advice-remove 'substitute-command-keys #'wakib-substitute-command-keys)
     (advice-remove 'describe-buffer-bindings #'wakib--describe-bindings-advice)))
 

--- a/wakib-keys.el
+++ b/wakib-keys.el
@@ -491,11 +491,6 @@ Then add C-d and C-e to KEYMAP"
     ("<escape>" . wakib-keyboard-quit)) ;; should quit minibuffer
   "List of all wakib mode keybindings.")
 
-
-(wakib-define-keys wakib-keys-overriding-map wakib-keylist)
-(add-to-list 'emulation-mode-map-alists
-	     `((wakib-keys . ,wakib-keys-overriding-map)))
-
 (defun wakib--tty-M-O (&optional arg)
   "Fix tty M-O to enable arrow keys."
   (interactive)
@@ -511,16 +506,18 @@ Then add C-d and C-e to KEYMAP"
 	       (setq temporary-goal-column 0)))
       (move-end-of-line arg))))
 
-(unless (display-graphic-p)
-  (define-key wakib-keys-overriding-map (kbd "M-O") 'wakib--tty-M-O))
-
-
 (defun wakib--setup ()
   "Runs after minor mode change to setup minor mode"
   (if wakib-keys
       (progn
-	(advice-add 'substitute-command-keys :around #'wakib-substitute-command-keys)
-	(advice-add 'describe-buffer-bindings :around #'wakib--describe-bindings-advice))
+        (advice-add 'substitute-command-keys :around #'wakib-substitute-command-keys)
+	(advice-add 'describe-buffer-bindings :around #'wakib--describe-bindings-advice)
+        (wakib-define-keys wakib-keys-overriding-map wakib-keylist)
+        (unless (display-graphic-p)
+          (define-key wakib-keys-overriding-map (kbd "M-O") 'wakib--tty-M-O))
+        (add-to-ordered-list 'emulation-mode-map-alists
+                             `((wakib-keys . ,wakib-keys-overriding-map)) 400))
+    (setq emulation-mode-map-alists (delq 'wakib-keys-overriding-map emulation-mode-map-alists))
     (advice-remove 'substitute-command-keys #'wakib-substitute-command-keys)
     (advice-remove 'describe-buffer-bindings #'wakib--describe-bindings-advice)))
 

--- a/wakib-keys.el
+++ b/wakib-keys.el
@@ -507,6 +507,8 @@ Then add C-d and C-e to KEYMAP"
       (move-end-of-line arg))))
 
 (defvar wakib--keymaps-initialized nil)
+(defvar wakib--keymap-alist
+  `((wakib-keys . ,wakib-keys-overriding-map)))
 
 (defun wakib--setup ()
   "Runs after minor mode change to setup minor mode"
@@ -520,10 +522,8 @@ Then add C-d and C-e to KEYMAP"
       (progn
         (advice-add 'substitute-command-keys :around #'wakib-substitute-command-keys)
         (advice-add 'describe-buffer-bindings :around #'wakib--describe-bindings-advice)
-        (add-to-ordered-list 'emulation-mode-map-alists
-                             `((wakib-keys . ,wakib-keys-overriding-map)) 400))
-    (setq emulation-mode-map-alists (delq `((wakib-keys . ,wakib-keys-overriding-map))
-                                          emulation-mode-map-alists))
+        (add-to-ordered-list 'emulation-mode-map-alists 'wakib--keymap-alist 400))
+    (setq emulation-mode-map-alists (delq 'wakib--keymap-alist emulation-mode-map-alists))
     (advice-remove 'substitute-command-keys #'wakib-substitute-command-keys)
     (advice-remove 'describe-buffer-bindings #'wakib--describe-bindings-advice)))
 


### PR DESCRIPTION
The keybindings must be defined in the minor mode definition, also it must remove the keybindings from emulation-mode-map-alists when the mode is off