### PR TITLE
Remove 'wakib--tty-M-O'

### DIFF
--- a/wakib-keys.el
+++ b/wakib-keys.el
@@ -260,7 +260,19 @@ ARG used as repeat for interactive function."
   "Used to add fucntionality to `wakib-next'."
   (interactive "p"))
 
-
+(defun wakib-keyboard-quit ()
+  "Quit the current command/process."
+  (interactive)
+  (cond
+   ((region-active-p)
+    (setq saved-region-selection nil)
+    (let (select-active-regions)
+      (deactivate-mark)))
+   ((> (minibuffer-depth) 0)
+    (abort-recursive-edit))
+   ((> (recursion-depth) 0)
+    (exit-recursive-edit))
+   (t (keyboard-quit))))
 
 ;; might be a more functional way to do this
 (defun wakib-select-line-block-all ()
@@ -476,7 +488,7 @@ Then add C-d and C-e to KEYMAP"
     ("<C-S-return>" . wakib-insert-line-before)
     ("C-b" . switch-to-buffer)
     ("M-X" . pp-eval-expression)
-    ("<escape>" . keyboard-quit)) ;; should quit minibuffer
+    ("<escape>" . wakib-keyboard-quit)) ;; should quit minibuffer
   "List of all wakib mode keybindings.")
 
 

--- a/wakib-keys.el
+++ b/wakib-keys.el
@@ -496,25 +496,6 @@ Then add C-d and C-e to KEYMAP"
 (add-to-list 'emulation-mode-map-alists
 	     `((wakib-keys . ,wakib-keys-overriding-map)))
 
-(defun wakib--tty-M-O (&optional arg)
-  "Fix tty M-O to enable arrow keys."
-  (interactive)
-  (let ((key (read-char nil nil 0.01)))
-    (if key
-	;; temporary-goal-column needs to be reset otherwise
-	;; up and down arrows end moving to old column
-	(cond ((eq key 65) (forward-line (- arg)))
-	      ((eq key 66) (forward-line (+ arg)))
-	      ((eq key 67) (right-char arg)
-	       (setq temporary-goal-column 0))
-	      ((eq key 68) (left-char arg)
-	       (setq temporary-goal-column 0)))
-      (move-end-of-line arg))))
-
-(unless (display-graphic-p)
-  (define-key wakib-keys-overriding-map (kbd "M-O") 'wakib--tty-M-O))
-
-
 (defun wakib--setup ()
   "Runs after minor mode change to setup minor mode"
   (if wakib-keys


### PR DESCRIPTION
Using `wakib` in emacs terminal conflict with the arrow keys, making them unusable, i found that 'wakib--tty-M-O' was causing this issue; the function docstring doesn't seems to be clear about what it does and why, so i think it would be better remove this.